### PR TITLE
fix that logfile closes too earlier

### DIFF
--- a/redistest.go
+++ b/redistest.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -45,7 +46,13 @@ type Server struct {
 type Config map[string]string
 
 func (config Config) write(wc io.Writer) error {
-	for key, value := range config {
+	keys := make([]string, 0, len(config))
+	for key := range config {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := config[key]
 		if _, err := fmt.Fprintf(wc, "%s %s\n", key, value); err != nil {
 			return err
 		}

--- a/redistest.go
+++ b/redistest.go
@@ -178,7 +178,11 @@ func (server *Server) killAndWait() error {
 	if err := server.cmd.Process.Kill(); err != nil {
 		return err
 	}
-	if _, err := server.cmd.Process.Wait(); err != nil {
+	if err := server.cmd.Wait(); err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			// err may be "signal: killed". ignore it.
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/redistest_test.go
+++ b/redistest_test.go
@@ -34,20 +34,18 @@ func TestConfig(t *testing.T) {
 func TestConnectRedisViaUnixScoket(t *testing.T) {
 	s, err := NewServer(true, nil)
 	if err != nil {
-		t.Error("NewServer is err:", err.Error())
+		t.Fatal("NewServer is err:", err.Error())
 	}
 	defer s.Stop()
 
 	t.Log("unixsocket:", s.Config["unixsocket"])
 	conn, err := redis.Dial("unix", s.Config["unixsocket"])
 	if err != nil {
-		t.Error("failed to connect to redis via unixscoket:", err.Error())
-		return
+		t.Fatal("failed to connect to redis via unixscoket:", err.Error())
 	}
 	_, err = conn.Do("PING")
 	if err != nil {
-		t.Error("failed to execute command:", err)
-		return
+		t.Fatal("failed to execute command:", err)
 	}
 }
 
@@ -55,19 +53,16 @@ func TestConnectRedisViaTCP(t *testing.T) {
 	// empty port
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Error("failed to listen", err)
-		return
+		t.Fatal("failed to listen", err)
 	}
 
 	if err := l.Close(); err != nil {
-		t.Error("failed to close", err)
-		return
+		t.Fatal("failed to close", err)
 	}
 
 	_, port, err := net.SplitHostPort(l.Addr().String())
 	if err != nil {
-		t.Error("err", err)
-		return
+		t.Fatal("err", err)
 	}
 
 	t.Log("empty port:", port)
@@ -76,13 +71,13 @@ func TestConnectRedisViaTCP(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Error("NewServer is err:", err.Error())
+		t.Fatal("NewServer is err:", err.Error())
 	}
 	defer s.Stop()
 
 	conn, err := redis.Dial("tcp", net.JoinHostPort("127.0.0.1", port))
 	if err != nil {
-		t.Error("failed to connect to redis via tcp:", err.Error())
+		t.Fatal("failed to connect to redis via tcp:", err.Error())
 		return
 	}
 	_, err = conn.Do("PING")
@@ -95,26 +90,25 @@ func TestConnectRedisViaTCP(t *testing.T) {
 func TestAutoStart(t *testing.T) {
 	s, err := NewServer(false, nil)
 	if err != nil {
-		t.Error("NewServer is err:", err.Error())
+		t.Fatal("NewServer is err:", err.Error())
 	}
-	defer s.Stop()
 
 	t.Log("unixsocket:", s.Config["unixsocket"])
 	_, err = redis.Dial("unix", s.Config["unixsocket"])
 
 	if err == nil {
-		t.Error("should not connect to redis server. because redis server is not runing yet")
-		return
+		t.Fatal("should not connect to redis server. because redis server is not runing yet")
 	}
 
 	t.Log("start redis server immediately")
 	if err := s.Start(); err != nil {
-		t.Error("failed to start", err)
+		t.Fatal("failed to start", err)
 	}
+	defer s.Stop()
 
 	conn, err := redis.Dial("unix", s.Config["unixsocket"])
 	if err != nil {
-		t.Error("failed to connect to redis via unixscoket:", err.Error())
+		t.Fatal("failed to connect to redis via unixscoket:", err.Error())
 		return
 	}
 	_, err = conn.Do("PING")

--- a/redistest_test.go
+++ b/redistest_test.go
@@ -36,7 +36,11 @@ func TestConnectRedisViaUnixScoket(t *testing.T) {
 	if err != nil {
 		t.Fatal("NewServer is err:", err.Error())
 	}
-	defer s.Stop()
+	defer func() {
+		if err := s.Stop(); err != nil {
+			t.Fatal("failed to stop", err)
+		}
+	}()
 
 	t.Log("unixsocket:", s.Config["unixsocket"])
 	conn, err := redis.Dial("unix", s.Config["unixsocket"])
@@ -73,7 +77,11 @@ func TestConnectRedisViaTCP(t *testing.T) {
 	if err != nil {
 		t.Fatal("NewServer is err:", err.Error())
 	}
-	defer s.Stop()
+	defer func() {
+		if err := s.Stop(); err != nil {
+			t.Fatal("failed to stop", err)
+		}
+	}()
 
 	conn, err := redis.Dial("tcp", net.JoinHostPort("127.0.0.1", port))
 	if err != nil {
@@ -104,7 +112,11 @@ func TestAutoStart(t *testing.T) {
 	if err := s.Start(); err != nil {
 		t.Fatal("failed to start", err)
 	}
-	defer s.Stop()
+	defer func() {
+		if err := s.Stop(); err != nil {
+			t.Fatal("failed to stop", err)
+		}
+	}()
 
 	conn, err := redis.Dial("unix", s.Config["unixsocket"])
 	if err != nil {


### PR DESCRIPTION
> err write /var/folders/h8/2168rv952tqgndhdpxbq80200000gn/T/redistest094365362/redis-server.log: file already closed

というエラーが出て怖かったので修正しました。(実害はない？ようですが)
`defer logfile.Close()` したあとも、logfileにstdout, stderrをコピーするgoroutineが動いていたようです。

ファイルではなくbufferに出力するようにして、回収はGCに任せるようにしました。